### PR TITLE
Track renamed ORCA STM32 firmware binary

### DIFF
--- a/orca_auv_rpi_ros2_ws/scripts/flash_stm32.sh
+++ b/orca_auv_rpi_ros2_ws/scripts/flash_stm32.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-st-flash --reset write /root/orca_auv_rpi_ros2_ws/stm32_binary/SAUVC2024.bin 0x08000000
+st-flash --reset write /root/orca_auv_rpi_ros2_ws/stm32_binary/ORCA-STM32.bin 0x08000000

--- a/orca_auv_rpi_ros2_ws/src/orca_rpi_stm32_bridge/orca_rpi_stm32_bridge/stm32_flasher_node.py
+++ b/orca_auv_rpi_ros2_ws/src/orca_rpi_stm32_bridge/orca_rpi_stm32_bridge/stm32_flasher_node.py
@@ -13,7 +13,7 @@ class Stm32FlasherNode(Node):
     def __init__(self) -> None:
         super().__init__('stm32_flasher_node')
 
-        self.declare_parameter('bin_path', '/root/orca_auv_rpi_ros2_ws/stm32_binary/SAUVC2024.bin')
+        self.declare_parameter('bin_path', '/root/orca_auv_rpi_ros2_ws/stm32_binary/ORCA-STM32.bin')
         self.declare_parameter('flash_address', '0x08000000')
         self.declare_parameter('st_flash_cmd', 'st-flash')
 


### PR DESCRIPTION
## Summary
- update the STM32 flashing paths to use `ORCA-STM32.bin`
- advance the STM32 submodule to the commit with the rebuilt renamed binary
- keep the RPI repo aligned with the newest STM32 firmware artifact

## Verification
- confirmed `stm32_flasher_node.py` points to `ORCA-STM32.bin`
- confirmed `flash_stm32.sh` points to `ORCA-STM32.bin`
- updated submodule pointer to `0b34ac6`