### PR TITLE
Declare GUI ROS dependencies

### DIFF
--- a/rpi_ros2_ws/src/gui/package.xml
+++ b/rpi_ros2_ws/src/gui/package.xml
@@ -7,7 +7,12 @@
   <maintainer email="root@todo.todo">root</maintainer>
   <license>TODO: License declaration</license>
 
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>python3-aiohttp</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
   <depend>xy_translation_control_interfaces</depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
## Summary
- Add the ROS runtime packages imported by the GUI node to `gui/package.xml`.
- Ensure `rosdep install --from-paths src --ignore-src` can resolve GUI runtime dependencies directly.

## Verification
- `python3 -m py_compile rpi_ros2_ws/src/gui/gui/gui_node.py`
- `python3 -c "import xml.etree.ElementTree as ET; ET.parse('rpi_ros2_ws/src/gui/package.xml')"`
- `git diff --check`