### PR TITLE
Package thruster lookup table

### DIFF
--- a/rpi_ros2_ws/src/thrusters/setup.py
+++ b/rpi_ros2_ws/src/thrusters/setup.py
@@ -8,6 +8,9 @@ setup(
     name=package_name,
     version='0.0.0',
     packages=find_packages(exclude=['test']),
+    package_data={
+        package_name: ['thruster_lookup_table_16V.csv'],
+    },
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
@@ -15,7 +18,7 @@ setup(
         (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
     ],
     install_requires=['setuptools'],
-    zip_safe=True,
+    zip_safe=False,
     maintainer='root',
     maintainer_email='root@todo.todo',
     description='TODO: Package description',


### PR DESCRIPTION
## Summary
- Install `thruster_lookup_table_16V.csv` as package data for the `thrusters` Python package.
- Mark the package as not zip-safe because the runtime code opens the lookup table via a filesystem path next to `thrusters.__file__`.

## Verification
- `python3 -m py_compile rpi_ros2_ws/src/thrusters/setup.py rpi_ros2_ws/src/thrusters/thrusters/thruster_force_to_pwm_output_signal_node.py`
- `git diff --check`