### PR TITLE
Use STM32-reported thruster enabled status

### DIFF
--- a/rpi_ros2_ws/src/thrusters/thrusters/thruster_initialization_node.py
+++ b/rpi_ros2_ws/src/thrusters/thrusters/thruster_initialization_node.py
@@ -21,7 +21,7 @@ class ThrusterInitializationNode(Node):
 
         self.__set_pwm_output_on_publisher = self.create_publisher(
             msg_type=Bool,
-            topic="thrusters/enabled",
+            topic="thrusters/set_enabled",
             qos_profile=10
         )
 


### PR DESCRIPTION
## Summary
- publish RPi thruster enable commands on `thrusters/set_enabled`
- leave `thrusters/enabled` as the STM32-reported status consumed by supervisor/GUI
- update `SAUVC-STM32` submodule pointer to merged STM32 main containing NCTU-AUV/SAUVC-STM32#30

## Verification
- ran `python3 -m compileall -q rpi_ros2_ws/src`
- ran README micro-ROS static library generation container
- ran `make` in `SAUVC-STM32` successfully and rebuilt `build/ORCA-STM32.bin`
- ran `make launch`; ROS processes started, then container was stopped for cleanup. Hardware warnings observed: no /dev/video0 and no ST-Link device.