### PR TITLE
feat: add Linear GUI manual control 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
       ROS_LOCALHOST_ONLY: ${ROS_LOCALHOST_ONLY:-0}
       RMW_IMPLEMENTATION: ${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+      FASTDDS_BUILTIN_TRANSPORTS: ${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}
     volumes:
       - /dev:/dev
       - ./rpi_ros2_ws:/root/rpi_ros2_ws

--- a/rpi_ros2_ws/src/gui/gui/backend/protocol.py
+++ b/rpi_ros2_ws/src/gui/gui/backend/protocol.py
@@ -22,6 +22,7 @@ MESSAGE_TYPES = (TYPE_ACTION, TYPE_TOPIC, TYPE_PROCESS, TYPE_CONTROLLER)
 ACTION_INITIALIZE_ALL_THRUSTERS = "initialize_all_thrusters"
 ACTION_FLASH_STM32 = "flash_stm32"
 ACTION_SET_SUPERVISOR_SIMULATION_MODE = "set_supervisor_simulation_mode"
+ACTION_SET_GUI_CONTROL_ENABLED = "set_gui_control_enabled"
 ACTION_MOVE_TO_POINT = "move_to_point"
 ACTION_CANCEL_MOVE_TO_POINT = "cancel_move_to_point"
 

--- a/rpi_ros2_ws/src/gui/gui/gui_node.py
+++ b/rpi_ros2_ws/src/gui/gui/gui_node.py
@@ -294,6 +294,8 @@ class GUINode(Node):
                 self._flash_stm32()
             elif action_name == protocol.ACTION_SET_SUPERVISOR_SIMULATION_MODE:
                 self._set_supervisor_simulation_mode(bool(msg_data.get("enabled")))
+            elif action_name == protocol.ACTION_SET_GUI_CONTROL_ENABLED:
+                self._set_gui_control_enabled(msg_data.get("enabled") is True)
             elif action_name == protocol.ACTION_MOVE_TO_POINT:
                 self._send_move_to_point_goal(msg_data)
             elif action_name == protocol.ACTION_CANCEL_MOVE_TO_POINT:
@@ -744,6 +746,74 @@ class GUINode(Node):
         for res in response.results:
             if not res.successful:
                 self.get_logger().warning(f"Param set failed on {node_name}: {res.reason}")
+
+    def _publish_zero_wrench(self):
+        self._set_output_wrench_at_center_publisher.publish(Wrench())
+
+    def _set_gui_control_enabled(self, enabled: bool):
+        if enabled:
+            self._enable_gui_control()
+            return
+        self._disable_gui_control()
+
+    def _enable_gui_control(self):
+        client = self._get_param_client("supervisor_node")
+        if not client.service_is_ready():
+            message = "Supervisor parameter service not ready"
+            self.get_logger().warning(message)
+            self.aiohttp_server.send_topic(
+                protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+                message,
+            )
+            return
+
+        self.aiohttp_server.send_topic(
+            protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+            "Enabling GUI control: simulation safety bypass",
+        )
+        parameters = [
+            Parameter("require_not_killed", Parameter.Type.BOOL, False),
+            Parameter("require_thrusters_enabled", Parameter.Type.BOOL, False),
+        ]
+        future = client.set_parameters(parameters)
+        future.add_done_callback(self._on_gui_control_safety_params_result)
+
+    def _on_gui_control_safety_params_result(self, future):
+        try:
+            response = future.result()
+        except Exception as exc:  # noqa: BLE001
+            message = f"GUI control enable failed: {exc}"
+            self.get_logger().warning(message)
+            self.aiohttp_server.send_topic(
+                protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+                message,
+            )
+            return
+
+        for res in response.results:
+            if not res.successful:
+                message = f"GUI control enable rejected: {res.reason}"
+                self.get_logger().warning(message)
+                self.aiohttp_server.send_topic(
+                    protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+                    message,
+                )
+                return
+
+        self.get_logger().info("GUI control safety bypass enabled; switching to MANUAL")
+        self.aiohttp_server.send_topic(
+            protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+            "GUI control safety bypass enabled; switching to MANUAL",
+        )
+        self._call_supervisor(protocol.SUPERVISOR_SERVICE_MANUAL)
+
+    def _disable_gui_control(self):
+        self._publish_zero_wrench()
+        self.aiohttp_server.send_topic(
+            protocol.TOPIC_SYSTEM_MANAGER_STATUS,
+            "GUI control stopping; zero wrench sent",
+        )
+        self._call_supervisor(protocol.SUPERVISOR_SERVICE_SAFE_DISABLED)
 
     def _set_group_pid_params(self, group: str, params):
         nodes = self._controller_groups.get(group, [])

--- a/rpi_ros2_ws/src/gui/gui/static/controller/controller.html
+++ b/rpi_ros2_ws/src/gui/gui/static/controller/controller.html
@@ -4,20 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ORCA AUV Fullscreen Controller</title>
+    <link rel="stylesheet" href="/static/shared/linear_theme.css">
     <style>
-        * {
-            box-sizing: border-box;
-        }
-
         body {
-            margin: 0;
             width: 100vw;
             height: 100vh;
             overflow: hidden;
             position: relative;
-            background: #000;
-            font-family: "Space Grotesk", "Noto Sans", sans-serif;
-            color: #ffffff;
         }
 
         #camera_feed {
@@ -36,25 +29,35 @@
             top: 20px;
             left: 20px;
             min-width: 320px;
-            background: rgba(0, 0, 0, 0.5);
-            color: #ffffff;
             padding: 14px 16px;
-            border-radius: 12px;
-            border: 1px solid rgba(255, 255, 255, 0.25);
-            backdrop-filter: blur(4px);
+            background: rgba(15, 16, 17, 0.92);
+            backdrop-filter: blur(10px);
             line-height: 1.5;
             z-index: 1;
         }
 
         .hud-title {
             font-size: 16px;
-            font-weight: 700;
+            font-weight: 600;
             margin-bottom: 8px;
         }
 
         .hud-row {
             margin: 4px 0;
             font-size: 14px;
+        }
+        .hud-status {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0 10px;
+        }
+        .hud-control {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            margin: 10px 0 12px;
         }
 
         .wrench {
@@ -69,13 +72,12 @@
         .control-help {
             margin-top: 12px;
             padding-top: 10px;
-            border-top: 1px solid rgba(255, 255, 255, 0.2);
+            border-top: 1px solid var(--linear-hairline);
         }
 
         .control-help-title {
             font-size: 13px;
-            font-weight: 700;
-            letter-spacing: 0.02em;
+            font-weight: 600;
             margin-bottom: 6px;
         }
 
@@ -91,8 +93,8 @@
             display: inline-block;
             padding: 1px 6px;
             border-radius: 6px;
-            border: 1px solid rgba(255, 255, 255, 0.3);
-            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid var(--linear-hairline-strong);
+            background: var(--linear-surface-2);
             font-weight: 600;
             white-space: nowrap;
         }
@@ -100,18 +102,18 @@
         .thruster-panel {
             margin-top: 12px;
             padding-top: 10px;
-            border-top: 1px solid rgba(255, 255, 255, 0.2);
+            border-top: 1px solid var(--linear-hairline);
         }
 
         .thruster-panel-title {
             font-size: 13px;
-            font-weight: 700;
+            font-weight: 600;
             margin-bottom: 6px;
         }
 
         .thruster-panel-note {
             font-size: 11px;
-            opacity: 0.8;
+            color: var(--linear-ink-subtle);
             margin-bottom: 6px;
         }
 
@@ -127,6 +129,11 @@
             justify-content: space-between;
             gap: 8px;
             white-space: nowrap;
+            color: var(--linear-ink-muted);
+        }
+        .thruster-item strong,
+        .wrench strong {
+            color: var(--linear-primary-hover);
         }
 
         @media (max-width: 640px) {
@@ -144,8 +151,18 @@
 
     <div class="hud">
         <div class="hud-title">ORCA AUV Controller HUD</div>
-        <div class="hud-row">WebSocket: <span id="ws_status">🔴 Disconnected</span></div>
-        <div class="hud-row">Gamepad: <span id="gamepad_status">🎮 請按下搖桿任意鍵...</span></div>
+        <div class="hud-status">
+            <span class="status-chip"><strong>WebSocket</strong><span id="ws_status">Disconnected</span></span>
+            <span class="status-chip"><strong>Mode</strong><span id="system_manager_mode">none</span></span>
+        </div>
+        <div class="hud-row">Gamepad: <span id="gamepad_status">請按下搖桿任意鍵...</span></div>
+        <div class="hud-control">
+            <span class="control-label">GUI Control</span>
+            <div class="segmented-control" role="group" aria-label="GUI control mode">
+                <button id="gui_control_manual_button" class="button-primary" onclick="gui_control_manual_button_onclick()">MANUAL</button>
+                <button id="gui_control_safe_button" onclick="gui_control_safe_button_onclick()">SAFE</button>
+            </div>
+        </div>
         <div class="hud-row wrench">Current Wrench:</div>
         <div class="hud-row">
             <span>X: <strong id="thrust_x">0.00</strong></span>

--- a/rpi_ros2_ws/src/gui/gui/static/controller/controller.js
+++ b/rpi_ros2_ws/src/gui/gui/static/controller/controller.js
@@ -5,6 +5,9 @@ const thrustYElement = document.getElementById("thrust_y");
 const thrustZElement = document.getElementById("thrust_z");
 const thrustYawElement = document.getElementById("thrust_yaw");
 const cameraFeedElement = document.getElementById("camera_feed");
+const systemManagerModeElement = document.getElementById("system_manager_mode");
+const guiControlManualButton = document.getElementById("gui_control_manual_button");
+const guiControlSafeButton = document.getElementById("gui_control_safe_button");
 const thrusterPwmElements = Array.from({ length: 8 }, (_, index) =>
     document.getElementById(`thruster_pwm_${index}`)
 );
@@ -32,6 +35,7 @@ let activeGamepadIndex = null;
 let animationFrameId = null;
 let lastSendTime = 0;
 let lastBPressed = false;
+let currentSystemManagerMode = null;
 const pressedKeys = new Set();
 
 const websocket = new WebSocket(
@@ -55,7 +59,7 @@ function updateWsStatus(connected) {
     if (!wsStatusElement) {
         return;
     }
-    wsStatusElement.textContent = connected ? "🟢 Connected" : "🔴 Disconnected";
+    wsStatusElement.textContent = connected ? "Connected" : "Disconnected";
 }
 
 function updateGamepadStatus(text) {
@@ -78,6 +82,41 @@ function updateHudWrench() {
     if (thrustYawElement) {
         thrustYawElement.textContent = current_wrench.torque.z.toFixed(2);
     }
+}
+
+function updateGuiControlState(mode) {
+    const isManual = mode === "MANUAL";
+    if (systemManagerModeElement) {
+        systemManagerModeElement.textContent = mode || "none";
+    }
+    if (guiControlManualButton) {
+        guiControlManualButton.classList.toggle("is-active", isManual);
+        guiControlManualButton.setAttribute("aria-pressed", String(isManual));
+    }
+    if (guiControlSafeButton) {
+        guiControlSafeButton.classList.toggle("is-active", !isManual);
+        guiControlSafeButton.setAttribute("aria-pressed", String(!isManual));
+    }
+}
+
+function setGuiControlEnabled(enabled) {
+    if (websocket.readyState !== WebSocket.OPEN) {
+        return;
+    }
+    websocket.send(JSON.stringify(protocol.makeActionMessage(
+        protocol.actions.setGuiControlEnabled,
+        {enabled: enabled}
+    )));
+}
+
+function gui_control_manual_button_onclick() {
+    setGuiControlEnabled(true);
+}
+
+function gui_control_safe_button_onclick() {
+    setWrenchToZero();
+    sendCurrentWrench();
+    setGuiControlEnabled(false);
 }
 
 function applyDeadzone(value) {
@@ -156,7 +195,7 @@ function getActiveGamepad() {
 }
 
 function applyGamepadInput(gamepad) {
-    updateGamepadStatus("🎮 已連接: " + gamepad.id);
+    updateGamepadStatus("已連接: " + gamepad.id);
 
     const leftX = applyDeadzone(gamepad.axes[0] || 0);
     const leftY = applyDeadzone(gamepad.axes[1] || 0);
@@ -198,9 +237,9 @@ function applyKeyboardInput() {
     current_wrench.torque.z = (yawRight ? max_twist : 0) + (yawLeft ? -max_twist : 0);
 
     if (pressedKeys.size > 0) {
-        updateGamepadStatus("⌨️ 鍵盤控制中");
+        updateGamepadStatus("鍵盤控制中");
     } else {
-        updateGamepadStatus("🎮 未連接，使用鍵盤控制");
+        updateGamepadStatus("未連接，使用鍵盤控制");
     }
 
     updateHudWrench();
@@ -226,14 +265,14 @@ function tickControls() {
 
 window.addEventListener("gamepadconnected", (event) => {
     activeGamepadIndex = event.gamepad.index;
-    updateGamepadStatus("🎮 已連接: " + event.gamepad.id);
+    updateGamepadStatus("已連接: " + event.gamepad.id);
 });
 
 window.addEventListener("gamepaddisconnected", (event) => {
     if (activeGamepadIndex === event.gamepad.index) {
         activeGamepadIndex = null;
         lastBPressed = false;
-        updateGamepadStatus("🎮 未連接，使用鍵盤控制");
+        updateGamepadStatus("未連接，使用鍵盤控制");
         setWrenchToZero();
         sendCurrentWrench();
     }
@@ -283,6 +322,12 @@ websocket.onmessage = (event) => {
 
     const topicName = msgJsonObject.data && msgJsonObject.data.topic_name;
     const topicMsg = msgJsonObject.data && msgJsonObject.data.msg;
+    if (topicName === protocol.topics.systemManagerMode) {
+        currentSystemManagerMode = topicMsg;
+        updateGuiControlState(currentSystemManagerMode);
+        return;
+    }
+
     if (topicName !== protocol.topics.thrustersPwmUs || !Array.isArray(topicMsg)) {
         return;
     }
@@ -301,6 +346,7 @@ websocket.onerror = () => {
 
 updateWsStatus(false);
 updateHudWrench();
+updateGuiControlState(currentSystemManagerMode);
 updateThrusterPwmDisplay(Array(8).fill(1500));
 initializeCameraFeed();
 animationFrameId = requestAnimationFrame(tickControls);

--- a/rpi_ros2_ws/src/gui/gui/static/dashboard/index.html
+++ b/rpi_ros2_ws/src/gui/gui/static/dashboard/index.html
@@ -2,48 +2,55 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ORCA AUV GUI</title>
+    <link rel="stylesheet" href="/static/shared/linear_theme.css">
     <style>
-        :root {
-            --bg: #0c1220;
-            --bg-alt: #111a2b;
-            --card: #161f33;
-            --text: #e7ecf6;
-            --muted: #9fb0d0;
-            --accent: #5ed1b6;
-            --accent-2: #7aa7ff;
-            --border: #27324a;
-            --shadow: rgba(4, 10, 22, 0.35);
-        }
-        * {
-            box-sizing: border-box;
-        }
         body {
-            margin: 0;
             padding: 24px;
-            font-family: "Space Grotesk", "Noto Sans", sans-serif;
-            color: var(--text);
-            background:
-                radial-gradient(900px 500px at 10% -10%, rgba(94, 209, 182, 0.16), transparent 60%),
-                radial-gradient(900px 500px at 90% -20%, rgba(122, 167, 255, 0.2), transparent 60%),
-                var(--bg);
-            line-height: 1.5;
         }
-        p, div {
-            margin: 0 0 12px;
+        .status-bar,
+        .panel {
+            margin-bottom: 16px;
         }
         .status-bar {
             display: flex;
             flex-wrap: wrap;
-            gap: 16px 24px;
+            gap: 12px;
             align-items: center;
-            margin-bottom: 16px;
+            justify-content: space-between;
+            padding: 14px 16px;
+            background: var(--linear-surface-1);
+            border: 1px solid var(--linear-hairline);
+            border-radius: 8px;
+        }
+        .status-main,
+        .status-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+        }
+        .control-block {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+        .toggle-secondary {
+            min-height: 32px;
+            padding: 5px 9px;
+            border: 1px solid var(--linear-hairline);
+            border-radius: 999px;
+            background: var(--linear-canvas);
+            color: var(--linear-ink-subtle);
+            font-size: 12px;
         }
         .row {
             display: flex;
             flex-wrap: wrap;
             gap: 8px 12px;
             align-items: center;
+            margin-bottom: 12px;
         }
         .grid-2 {
             display: grid;
@@ -64,6 +71,11 @@
             display: flex;
             flex-direction: column;
             gap: 8px;
+        }
+        .stack > div,
+        .panel > div,
+        .panel > p {
+            margin-bottom: 10px;
         }
         .inline-field {
             display: flex;
@@ -94,8 +106,8 @@
             align-items: center;
             min-width: 0;
             padding: 8px 10px;
-            background: var(--bg-alt);
-            border: 1px solid var(--border);
+            background: var(--linear-surface-2);
+            border: 1px solid var(--linear-hairline);
             border-radius: 8px;
         }
         .thruster-pwm-row .inline-field {
@@ -115,7 +127,7 @@
         .thruster-pwm-6 { grid-area: thruster-6; }
         .thruster-pwm-7 { grid-area: thruster-7; }
         .thruster-pwm-label {
-            color: var(--muted);
+            color: var(--linear-ink-subtle);
         }
         .thruster-pwm-panel {
             grid-column: 1 / -1;
@@ -133,8 +145,8 @@
             max-width: 260px;
             height: auto;
             border-radius: 8px;
-            border: 1px solid var(--border);
-            background: var(--bg-alt);
+            border: 1px solid var(--linear-hairline);
+            background: var(--linear-surface-2);
         }
         @media (max-width: 920px) {
             .thruster-pwm-grid {
@@ -159,56 +171,70 @@
             grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
             gap: 16px;
         }
-        button {
-            border: 1px solid var(--border);
-            background: linear-gradient(135deg, rgba(94, 209, 182, 0.16), rgba(122, 167, 255, 0.18));
-            color: var(--text);
-            padding: 8px 14px;
-            border-radius: 10px;
-            cursor: pointer;
-            box-shadow: 0 8px 20px var(--shadow);
-            transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
-        }
-        button:hover {
-            transform: translateY(-1px);
-            border-color: rgba(94, 209, 182, 0.7);
-            box-shadow: 0 12px 28px var(--shadow);
-        }
-        button:active {
-            transform: translateY(0);
-        }
-        input[type="number"] {
-            width: 160px;
-            background: var(--bg-alt);
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 6px 10px;
-            border-radius: 8px;
-        }
-        input[type="number"]:focus {
-            outline: none;
-            border-color: var(--accent-2);
-            box-shadow: 0 0 0 2px rgba(122, 167, 255, 0.2);
-        }
-        input[type="checkbox"] {
-            width: 18px;
-            height: 18px;
-            accent-color: var(--accent);
-        }
         .panel {
-            background: var(--card);
             padding: 16px 18px;
-            border-radius: 14px;
-            border: 1px solid var(--border);
-            box-shadow: 0 10px 24px var(--shadow);
         }
-        body > p {
-            font-size: 15px;
-            color: var(--muted);
+        .panel > p,
+        .section-title {
+            color: var(--linear-ink);
+            font-size: 14px;
+            font-weight: 600;
         }
-        i {
-            color: var(--accent);
-            font-style: normal;
+        #stm32_debug_log {
+            max-height: 220px;
+            overflow: auto;
+            margin: 8px 0 0;
+            padding: 12px;
+        }
+        #gamepad_status {
+            margin-top: 8px;
+            padding: 12px;
+            background: var(--linear-canvas);
+            border: 1px solid var(--linear-hairline);
+            border-radius: 8px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 13px;
+        }
+        .section-kicker {
+            margin-bottom: 8px;
+            color: var(--linear-ink-muted);
+        }
+        .row-start {
+            align-items: flex-start;
+        }
+        .offset-top {
+            margin-top: 8px;
+        }
+        .spaced-block {
+            margin-bottom: 12px;
+        }
+        .gamepad-section {
+            margin-top: 8px;
+        }
+        .gamepad-values {
+            margin-top: 4px;
+            margin-left: 12px;
+        }
+        .status-value-muted {
+            color: var(--linear-ink-subtle);
+        }
+        @media (max-width: 760px) {
+            body {
+                padding: 12px;
+            }
+            .layout {
+                grid-template-columns: 1fr;
+            }
+            .status-bar {
+                align-items: stretch;
+            }
+            .status-main,
+            .status-actions {
+                width: 100%;
+            }
+            input[type="number"] {
+                width: 100%;
+            }
         }
     </style>
     <script src="/static/shared/protocol.js"></script>
@@ -216,17 +242,28 @@
 </head>
 <body>
     <div class="status-bar">
-        <div>sensors/killed: <i id="killed">none</i></div>
-        <div>system_manager/mode: <i id="system_manager_mode">none</i></div>
-        <div>system_manager/status: <i id="system_manager_status">none</i></div>
-        <label class="inline-field">
-            simulation
-            <input
-                type="checkbox"
-                id="supervisor_simulation_mode_input"
-                onchange="supervisor_simulation_mode_input_onchange()"
-            >
-        </label>
+        <div class="status-main">
+            <span class="status-chip"><strong>Killed</strong><i id="killed">none</i></span>
+            <span class="status-chip" id="system_manager_mode_chip"><strong>Mode</strong><i id="system_manager_mode">none</i></span>
+            <span class="status-chip"><strong>Status</strong><i id="system_manager_status">none</i></span>
+        </div>
+        <div class="status-actions">
+            <div class="control-block">
+                <span class="control-label">GUI Control</span>
+                <div class="segmented-control" role="group" aria-label="GUI control mode">
+                    <button id="gui_control_manual_button" class="button-primary" onclick="gui_control_manual_button_onclick()">MANUAL</button>
+                    <button id="gui_control_safe_button" onclick="gui_control_safe_button_onclick()">SAFE</button>
+                </div>
+            </div>
+            <label class="inline-field toggle-secondary">
+                simulation
+                <input
+                    type="checkbox"
+                    id="supervisor_simulation_mode_input"
+                    onchange="supervisor_simulation_mode_input_onchange()"
+                >
+            </label>
+        </div>
     </div>
 
     <div class="layout">
@@ -239,7 +276,7 @@
                 <div>diagnostics/stm32/log:</div>
                 <button onclick="clear_stm32_log_button_onclick()">clear</button>
             </div>
-            <pre id="stm32_debug_log" style="max-height: 220px; overflow: auto; margin: 8px 0 0;"></pre>
+            <pre id="stm32_debug_log"></pre>
         </div>
 
         <div class="panel">
@@ -291,14 +328,14 @@
                 <button onclick="reset_depth_control()">reset</button>
             </div>
             <div>
-                <div style="margin-bottom: 8px;">depth PID params:</div>
+                <div class="section-kicker">depth PID params:</div>
                 <div class="grid-2">
                     <div class="inline-field">P: <input type="number" step="any" id="depth_pid_p_input"></div>
                     <div class="inline-field">I: <input type="number" step="any" id="depth_pid_i_input"></div>
                     <div class="inline-field">D: <input type="number" step="any" id="depth_pid_d_input"></div>
                     <div class="inline-field">smoothing: <input type="number" step="any" id="depth_pid_smoothing_input"></div>
                 </div>
-                <div class="row" style="margin-top: 8px;">
+                <div class="row offset-top">
                     <button onclick="set_depth_pid_params_button_onclick()">set PID params</button>
                 </div>
             </div>
@@ -378,7 +415,7 @@
 
         <div class="panel">
             control/wrench_command:
-            <div class="row" style="align-items: flex-start;">
+            <div class="row row-start">
                 <div class="stack">
                     <div>force:</div>
                     <div class="inline-field">x: <input type="number" id="control_wrench_command_force_x"></div>
@@ -396,31 +433,31 @@
         </div>
 
         <div class="panel">
-            <div style="margin-bottom: 12px;">
+            <div class="spaced-block">
                 <strong>Xbox Gamepad Status:</strong>
-                <div id="gamepad_status" style="margin-top: 8px; padding: 12px; background: var(--bg-alt); border-radius: 8px; font-family: monospace; font-size: 13px;">
+                <div id="gamepad_status">
                     <div>Connection: <i id="gamepad_connection_status">Not Connected</i></div>
-                    <div style="margin-top: 8px;">
+                    <div class="gamepad-section">
                         <strong>Analog Sticks:</strong>
-                        <div style="margin-left: 12px; margin-top: 4px;">
+                        <div class="gamepad-values">
                             <div>Left Stick: X=<i id="gamepad_left_x">0.00</i> Y=<i id="gamepad_left_y">0.00</i></div>
                             <div>Right Stick: X=<i id="gamepad_right_x">0.00</i> Y=<i id="gamepad_right_y">0.00</i></div>
                         </div>
                     </div>
-                    <div style="margin-top: 8px;">
+                    <div class="gamepad-section">
                         <strong>Output Motion Control:</strong>
-                        <div style="margin-left: 12px; margin-top: 4px;">
+                        <div class="gamepad-values">
                             <div>Force X (fwd): <i id="gamepad_output_force_x">0.00</i> N</div>
                             <div>Force Y (strafe): <i id="gamepad_output_force_y">0.00</i> N</div>
                             <div>Force Z (depth): <i id="gamepad_output_force_z">0.00</i> N</div>
                             <div>Torque Z (rotation): <i id="gamepad_output_torque_z">0.00</i> Nm</div>
                         </div>
                     </div>
-                    <div style="margin-top: 8px;">
+                    <div class="gamepad-section">
                         <strong>Buttons:</strong>
-                        <div style="margin-left: 12px; margin-top: 4px;">
-                            <div>A (Init): <i id="gamepad_button_a" style="color: var(--muted);">Released</i></div>
-                            <div>B (E-Stop): <i id="gamepad_button_b" style="color: var(--muted);">Released</i></div>
+                        <div class="gamepad-values">
+                            <div>A (Init): <i id="gamepad_button_a" class="status-value-muted">Released</i></div>
+                            <div>B (E-Stop): <i id="gamepad_button_b" class="status-value-muted">Released</i></div>
                         </div>
                     </div>
                 </div>
@@ -443,7 +480,7 @@
                 </div>
             </div>
 
-            <div class="grid-3" style="margin-top: 8px;">
+            <div class="grid-3 offset-top">
                 <button id="push_down_button">push down</button>
                 <button id="push_up_button">push up</button>
                 <button id="push_left_button">push left</button>

--- a/rpi_ros2_ws/src/gui/gui/static/dashboard/main.js
+++ b/rpi_ros2_ws/src/gui/gui/static/dashboard/main.js
@@ -6,6 +6,7 @@ const websocket = new WebSocket(
 const stm32LogState = {
     shouldAutoScroll: true,
 };
+let currentSystemManagerMode = null;
 
 function isAtBottom(element, thresholdPx = 8) {
     return element.scrollTop + element.clientHeight >= element.scrollHeight - thresholdPx;
@@ -21,11 +22,11 @@ function updateStm32LogAutoScrollState() {
 
 document.addEventListener("DOMContentLoaded", () => {
     const element = document.getElementById("stm32_debug_log");
-    if (!element) {
-        return;
+    if (element) {
+        element.addEventListener("scroll", updateStm32LogAutoScrollState);
+        stm32LogState.shouldAutoScroll = isAtBottom(element);
     }
-    element.addEventListener("scroll", updateStm32LogAutoScrollState);
-    stm32LogState.shouldAutoScroll = isAtBottom(element);
+    updateGuiControlState(currentSystemManagerMode);
 });
 
 websocket.onmessage = (event) => {
@@ -58,10 +59,12 @@ websocket.onmessage = (event) => {
             }
         }
         if (msg_json_object.data.topic_name == protocol.topics.systemManagerMode) {
+            currentSystemManagerMode = msg_json_object.data.msg;
             const element = document.getElementById("system_manager_mode");
             if (element) {
-                element.innerHTML = msg_json_object.data.msg;
+                element.innerHTML = currentSystemManagerMode;
             }
+            updateGuiControlState(currentSystemManagerMode);
         }
         if (msg_json_object.data.topic_name == protocol.topics.systemManagerStatus) {
             const element = document.getElementById("system_manager_status");
@@ -206,6 +209,46 @@ function set_supervisor_simulation_mode(enabled) {
 function supervisor_simulation_mode_input_onchange() {
     const checkbox = document.getElementById("supervisor_simulation_mode_input");
     set_supervisor_simulation_mode(Boolean(checkbox && checkbox.checked));
+}
+
+function set_gui_control_enabled(enabled) {
+    const statusElement = document.getElementById("system_manager_status");
+    if (statusElement) {
+        statusElement.innerHTML = enabled
+            ? "Enabling GUI control..."
+            : "Stopping GUI control...";
+    }
+    websocket.send(JSON.stringify(protocol.makeActionMessage(
+        protocol.actions.setGuiControlEnabled,
+        {enabled: enabled}
+    )));
+}
+
+function gui_control_manual_button_onclick() {
+    set_gui_control_enabled(true);
+}
+
+function gui_control_safe_button_onclick() {
+    set_gui_control_enabled(false);
+}
+
+function updateGuiControlState(mode) {
+    const manualButton = document.getElementById("gui_control_manual_button");
+    const safeButton = document.getElementById("gui_control_safe_button");
+    const modeChip = document.getElementById("system_manager_mode_chip");
+    const isManual = mode === "MANUAL";
+
+    if (manualButton) {
+        manualButton.classList.toggle("is-active", isManual);
+        manualButton.setAttribute("aria-pressed", String(isManual));
+    }
+    if (safeButton) {
+        safeButton.classList.toggle("is-active", !isManual);
+        safeButton.setAttribute("aria-pressed", String(!isManual));
+    }
+    if (modeChip) {
+        modeChip.classList.toggle("is-active", isManual);
+    }
 }
 
 function set_target_depth_m_button_onclick() {

--- a/rpi_ros2_ws/src/gui/gui/static/shared/gamepad_control.js
+++ b/rpi_ros2_ws/src/gui/gui/static/shared/gamepad_control.js
@@ -205,10 +205,10 @@ function updateGamepadConnectionStatus() {
     if (statusElement) {
         if (gamepadState.connected) {
             statusElement.textContent = "Connected ✓";
-            statusElement.style.color = "var(--accent)";
+            statusElement.style.color = "var(--linear-primary-hover)";
         } else {
             statusElement.textContent = "Not Connected";
-            statusElement.style.color = "var(--muted)";
+            statusElement.style.color = "var(--linear-ink-subtle)";
         }
     }
 }
@@ -269,10 +269,10 @@ function updateGamepadButtonDisplay(buttonAPressed, buttonBPressed) {
     if (buttonAElem) {
         if (buttonAPressed) {
             buttonAElem.textContent = "Pressed ✓";
-            buttonAElem.style.color = "var(--accent)";
+            buttonAElem.style.color = "var(--linear-primary-hover)";
         } else {
             buttonAElem.textContent = "Released";
-            buttonAElem.style.color = "var(--muted)";
+            buttonAElem.style.color = "var(--linear-ink-subtle)";
         }
     }
     
@@ -282,7 +282,7 @@ function updateGamepadButtonDisplay(buttonAPressed, buttonBPressed) {
             buttonBElem.style.color = "#ff6b6b";
         } else {
             buttonBElem.textContent = "Released";
-            buttonBElem.style.color = "var(--muted)";
+            buttonBElem.style.color = "var(--linear-ink-subtle)";
         }
     }
 }

--- a/rpi_ros2_ws/src/gui/gui/static/shared/linear_theme.css
+++ b/rpi_ros2_ws/src/gui/gui/static/shared/linear_theme.css
@@ -1,0 +1,198 @@
+:root {
+    --linear-primary: #5e6ad2;
+    --linear-primary-hover: #828fff;
+    --linear-primary-focus: #5e69d1;
+    --linear-ink: #f7f8f8;
+    --linear-ink-muted: #d0d6e0;
+    --linear-ink-subtle: #8a8f98;
+    --linear-ink-tertiary: #62666d;
+    --linear-canvas: #010102;
+    --linear-surface-1: #0f1011;
+    --linear-surface-2: #141516;
+    --linear-surface-3: #18191a;
+    --linear-hairline: #23252a;
+    --linear-hairline-strong: #34343a;
+    --linear-success: #27a644;
+    --linear-danger: #dc4f4f;
+    --linear-shadow: rgba(0, 0, 0, 0.42);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: Inter, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif;
+    color: var(--linear-ink);
+    background: var(--linear-canvas);
+    line-height: 1.5;
+    letter-spacing: 0;
+}
+
+button,
+input,
+select,
+textarea {
+    font: inherit;
+    letter-spacing: 0;
+}
+
+button {
+    min-height: 34px;
+    border: 1px solid var(--linear-hairline-strong);
+    background: var(--linear-surface-2);
+    color: var(--linear-ink);
+    padding: 8px 14px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.2;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+button:hover {
+    background: var(--linear-surface-3);
+    border-color: var(--linear-primary);
+}
+
+button:focus-visible,
+input:focus-visible {
+    outline: none;
+    border-color: var(--linear-primary);
+    box-shadow: 0 0 0 2px rgba(94, 106, 210, 0.28);
+}
+
+button:active,
+button.is-active {
+    background: var(--linear-primary-focus);
+    border-color: var(--linear-primary-focus);
+    color: #ffffff;
+}
+
+.button-primary {
+    background: var(--linear-primary);
+    border-color: var(--linear-primary);
+    color: #ffffff;
+}
+
+.button-primary:hover {
+    background: var(--linear-primary-hover);
+    border-color: var(--linear-primary-hover);
+}
+
+.button-danger {
+    border-color: rgba(220, 79, 79, 0.62);
+    color: #ffd7d7;
+}
+
+.button-danger:hover {
+    background: rgba(220, 79, 79, 0.16);
+    border-color: var(--linear-danger);
+}
+
+input[type="number"],
+input[type="text"] {
+    width: 160px;
+    min-height: 34px;
+    background: var(--linear-surface-1);
+    border: 1px solid var(--linear-hairline);
+    color: var(--linear-ink);
+    padding: 7px 10px;
+    border-radius: 8px;
+    font-size: 14px;
+}
+
+input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--linear-primary);
+}
+
+.panel,
+.hud {
+    background: var(--linear-surface-1);
+    border: 1px solid var(--linear-hairline);
+    border-radius: 8px;
+    box-shadow: 0 18px 48px var(--linear-shadow);
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 26px;
+    max-width: 100%;
+    padding: 4px 9px;
+    border: 1px solid var(--linear-hairline);
+    border-radius: 999px;
+    background: var(--linear-surface-2);
+    color: var(--linear-ink-muted);
+    font-size: 12px;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.status-chip strong {
+    margin-right: 6px;
+    color: var(--linear-ink-subtle);
+    font-weight: 500;
+}
+
+.status-chip.is-active {
+    border-color: rgba(94, 106, 210, 0.72);
+    background: rgba(94, 106, 210, 0.16);
+    color: var(--linear-ink);
+}
+
+.segmented-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 3px;
+    border: 1px solid var(--linear-hairline);
+    border-radius: 10px;
+    background: var(--linear-canvas);
+}
+
+.control-label {
+    color: var(--linear-ink-subtle);
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.segmented-control button {
+    min-height: 30px;
+    border-color: transparent;
+    background: transparent;
+    color: var(--linear-ink-subtle);
+    box-shadow: none;
+}
+
+.segmented-control button:hover {
+    color: var(--linear-ink);
+    background: var(--linear-surface-2);
+    border-color: transparent;
+}
+
+.segmented-control button.is-active {
+    background: var(--linear-surface-2);
+    color: var(--linear-ink);
+    border-color: var(--linear-hairline-strong);
+}
+
+pre,
+.code-block {
+    background: var(--linear-canvas);
+    border: 1px solid var(--linear-hairline);
+    border-radius: 8px;
+    color: var(--linear-ink-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+i {
+    color: var(--linear-primary-hover);
+    font-style: normal;
+}

--- a/rpi_ros2_ws/src/gui/gui/static/shared/protocol.js
+++ b/rpi_ros2_ws/src/gui/gui/static/shared/protocol.js
@@ -22,6 +22,7 @@ const GuiProtocol = Object.freeze({
         initializeAllThrusters: "initialize_all_thrusters",
         flashStm32: "flash_stm32",
         setSupervisorSimulationMode: "set_supervisor_simulation_mode",
+        setGuiControlEnabled: "set_gui_control_enabled",
         moveToPoint: "move_to_point",
         cancelMoveToPoint: "cancel_move_to_point",
     }),

--- a/rpi_ros2_ws/src/gui/setup.py
+++ b/rpi_ros2_ws/src/gui/setup.py
@@ -12,6 +12,7 @@ setup(
             'static/controller/*.js',
             'static/dashboard/*.html',
             'static/dashboard/*.js',
+            'static/shared/*.css',
             'static/shared/*.js',
             'static/shared/*.png',
         ],


### PR DESCRIPTION
- 重新整理 dashboard 與 fullscreen controller 的 GUI 視覺風格，改為 Linear-style 暗色系介面。
- 新增 GUI Control 的 `MANUAL / SAFE` 切換。
- 啟用 MANUAL 時自動設定 simulation safety bypass，並切換 system manager 到 `MANUAL`。
- 切回 SAFE 時送出 zero wrench，並切換到 `SAFE_DISABLED`。
- 在 docker compose 固定 `FASTDDS_BUILTIN_TRANSPORTS=UDPv4`，降低 ROS 2 container discovery/transport 問題。